### PR TITLE
Add start screen header and button for game launch

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,17 @@
   </head>
   <body>
     <div id="app">
+      <header class="app-header" aria-label="ゲームの導入">
+        <h1 class="app-title">Tetorisu Party!</h1>
+        <button
+          id="start-button"
+          type="button"
+          class="start-button"
+          aria-label="ゲームを開始する"
+        >
+          ゲームスタート
+        </button>
+      </header>
       <main class="layout" role="application">
         <section class="playfield" aria-label="ゲームフィールド">
           <canvas id="playfield" width="360" height="720" aria-label="テトリスの盤面"></canvas>

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,16 +9,34 @@ function query<T extends HTMLElement>(selector: string): T {
   return element as T
 }
 
+const playfieldCanvas = query<HTMLCanvasElement>('#playfield')
+const nextCanvas = query<HTMLCanvasElement>('#next-preview')
+const pauseButton = query<HTMLButtonElement>('#pause-toggle')
+const controlButtons = Array.from(
+  document.querySelectorAll<HTMLButtonElement>('[data-action]'),
+)
+const startButton = query<HTMLButtonElement>('#start-button')
+
+pauseButton.disabled = true
+
 const app = new GameApp({
-  playfieldCanvas: query<HTMLCanvasElement>('#playfield'),
-  nextCanvas: query<HTMLCanvasElement>('#next-preview'),
-  pauseButton: query<HTMLButtonElement>('#pause-toggle'),
-  controlButtons: Array.from(
-    document.querySelectorAll<HTMLButtonElement>('[data-action]'),
-  ),
+  playfieldCanvas,
+  nextCanvas,
+  pauseButton,
+  controlButtons,
 })
 
-app.start()
+let hasStarted = false
+
+startButton.addEventListener('click', () => {
+  if (hasStarted) return
+  hasStarted = true
+  startButton.disabled = true
+  startButton.dataset.started = 'true'
+  startButton.textContent = 'プレイ中！'
+  pauseButton.disabled = false
+  app.start()
+})
 
 window.addEventListener('beforeunload', () => {
   app.dispose()

--- a/src/style.css
+++ b/src/style.css
@@ -23,6 +23,86 @@ body {
 
 #app {
   width: min(100%, 960px);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+  padding: 24px 20px;
+  border-radius: 20px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.1), rgba(13, 16, 22, 0.75));
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
+  text-align: center;
+}
+
+.app-title {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: linear-gradient(120deg, #ff71c5, #ffd966 45%, #63ffda);
+  -webkit-background-clip: text;
+  color: transparent;
+  text-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+.start-button {
+  padding: 14px 36px;
+  font-size: 1.125rem;
+  font-weight: 800;
+  border-radius: 999px;
+  border: none;
+  color: #0b0f15;
+  background: linear-gradient(135deg, #75f1ff, #7d8bff 45%, #ff8df4);
+  box-shadow:
+    0 14px 30px rgba(125, 139, 255, 0.35),
+    0 6px 12px rgba(255, 141, 244, 0.28);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+}
+
+.start-button::after {
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.start-button:hover {
+  transform: translateY(-3px) scale(1.02);
+  box-shadow:
+    0 18px 36px rgba(125, 139, 255, 0.45),
+    0 8px 16px rgba(255, 141, 244, 0.32);
+}
+
+.start-button:hover::after {
+  opacity: 1;
+}
+
+.start-button:active {
+  transform: translateY(1px);
+}
+
+.start-button:disabled {
+  cursor: default;
+  opacity: 0.7;
+  transform: none;
+  box-shadow:
+    0 10px 24px rgba(125, 139, 255, 0.25),
+    0 4px 10px rgba(255, 141, 244, 0.2);
+}
+
+.start-button[data-started='true'] {
+  background: linear-gradient(135deg, #8df8b1, #7df4ff);
 }
 
 .layout {

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -38,6 +38,7 @@ export class GameApp {
   private readonly controlButtons: HTMLButtonElement[]
   private readonly scoreElement: HTMLElement
   private currentState: GameViewState | null = null
+  private hasStarted = false
 
   constructor(options: AppOptions) {
     const playfieldCtx = options.playfieldCanvas.getContext('2d')
@@ -64,11 +65,14 @@ export class GameApp {
   }
 
   start() {
+    if (this.hasStarted) return
+    this.hasStarted = true
     this.pauseButton.textContent = 'Pause'
     this.loop.start()
   }
 
   togglePause() {
+    if (!this.hasStarted) return
     if (this.currentState?.isGameOver) {
       this.game.reset()
       const state = this.game.getState()
@@ -121,6 +125,7 @@ export class GameApp {
 
   private readonly handlePointerDown = (event: PointerEvent) => {
     const target = event.currentTarget as HTMLButtonElement
+    if (!this.hasStarted) return
     target.setAttribute('data-active', 'true')
     const action = target.dataset.action as ControlAction | undefined
     if (!action) return
@@ -129,6 +134,7 @@ export class GameApp {
 
   private readonly handlePointerUp = (event: PointerEvent) => {
     const target = event.currentTarget as HTMLButtonElement
+    if (!this.hasStarted) return
     target.removeAttribute('data-active')
     const action = target.dataset.action as ControlAction | undefined
     if (!action) return
@@ -136,6 +142,7 @@ export class GameApp {
   }
 
   private dispatchControl(action: ControlAction, pressed: boolean) {
+    if (!this.hasStarted) return
     switch (action) {
       case 'move-left':
         if (pressed) this.loop.moveLeft()
@@ -163,6 +170,13 @@ export class GameApp {
   private readonly handleKeyDown = (event: KeyboardEvent) => {
     if (event.repeat) return
 
+    if (!this.hasStarted) {
+      if (event.key === ' ') {
+        event.preventDefault()
+      }
+      return
+    }
+
     switch (event.key) {
       case 'ArrowLeft':
         this.loop.moveLeft()
@@ -188,6 +202,7 @@ export class GameApp {
   }
 
   private readonly handleKeyUp = (event: KeyboardEvent) => {
+    if (!this.hasStarted) return
     if (event.key === 'ArrowDown') {
       this.loop.setSoftDrop(false)
     }


### PR DESCRIPTION
## Summary
- add a vibrant header with a "Tetorisu Party!" title and start button above the game layout
- style the new start button with gradients and disabled state for a playful presentation
- require pressing the start button before enabling controls and starting the game loop

## Testing
- `docker compose run --rm app npm run build` *(fails: docker not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8254a9ec832994bbc647cb88696b