### PR TITLE
Adjust start flow and remove on-screen controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div id="app">
-      <header class="app-header" aria-label="ゲームの導入">
+      <section id="start-screen" class="start-screen" aria-label="ゲームの導入">
         <h1 class="app-title">Tetorisu Party!</h1>
         <button
           id="start-button"
@@ -17,8 +17,8 @@
         >
           ゲームスタート
         </button>
-      </header>
-      <main class="layout" role="application">
+      </section>
+      <main id="game-screen" class="layout" role="application" hidden>
         <section class="playfield" aria-label="ゲームフィールド">
           <canvas id="playfield" width="360" height="720" aria-label="テトリスの盤面"></canvas>
         </section>
@@ -33,14 +33,6 @@
               <span id="score-value" class="value">0</span>
             </div>
             <button id="pause-toggle" type="button" class="pause-button">Pause</button>
-          </section>
-          <section class="mobile-controls" aria-label="モバイル操作">
-            <div class="controls-grid">
-              <button type="button" data-action="move-left" class="control-button">←</button>
-              <button type="button" data-action="soft-drop" class="control-button">↓</button>
-              <button type="button" data-action="move-right" class="control-button">→</button>
-              <button type="button" data-action="rotate-right" class="control-button control-button--rotate">↻</button>
-            </div>
           </section>
         </aside>
       </main>

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,18 +12,18 @@ function query<T extends HTMLElement>(selector: string): T {
 const playfieldCanvas = query<HTMLCanvasElement>('#playfield')
 const nextCanvas = query<HTMLCanvasElement>('#next-preview')
 const pauseButton = query<HTMLButtonElement>('#pause-toggle')
-const controlButtons = Array.from(
-  document.querySelectorAll<HTMLButtonElement>('[data-action]'),
-)
 const startButton = query<HTMLButtonElement>('#start-button')
+const startScreen = query<HTMLElement>('#start-screen')
+const gameScreen = query<HTMLElement>('#game-screen')
 
 pauseButton.disabled = true
+startScreen.hidden = false
+gameScreen.hidden = true
 
 const app = new GameApp({
   playfieldCanvas,
   nextCanvas,
   pauseButton,
-  controlButtons,
 })
 
 let hasStarted = false
@@ -35,6 +35,8 @@ startButton.addEventListener('click', () => {
   startButton.dataset.started = 'true'
   startButton.textContent = 'プレイ中！'
   pauseButton.disabled = false
+  startScreen.hidden = true
+  gameScreen.hidden = false
   app.start()
 })
 

--- a/src/style.css
+++ b/src/style.css
@@ -21,13 +21,7 @@ body {
   background: radial-gradient(circle at 50% 20%, #14161a, #050607 70%);
 }
 
-#app {
-  width: min(100%, 960px);
-  display: flex;
-  flex-direction: column;
-}
-
-.app-header {
+.start-screen {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -38,6 +32,13 @@ body {
   background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.1), rgba(13, 16, 22, 0.75));
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
   text-align: center;
+}
+
+#app {
+  width: min(100%, 960px);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .app-title {
@@ -137,8 +138,7 @@ body {
 }
 
 .next,
-.hud,
-.mobile-controls {
+.hud {
   padding: 12px;
   border-radius: 14px;
   background: rgba(18, 22, 30, 0.85);
@@ -204,45 +204,6 @@ body {
   transform: translateY(1px);
 }
 
-.mobile-controls {
-  display: flex;
-  justify-content: center;
-}
-
-.controls-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  width: 100%;
-  max-width: 220px;
-}
-
-.control-button {
-  height: 64px;
-  border: none;
-  border-radius: 12px;
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: #0c1117;
-  background: linear-gradient(145deg, #9de3ff, #59c4ff);
-  cursor: pointer;
-}
-
-.control-button:active {
-  transform: translateY(1px);
-}
-
-.control-button[data-active='true'] {
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.2);
-}
-
-.control-button--rotate {
-  grid-column: span 2;
-  height: 72px;
-  font-size: 1.4rem;
-  background: linear-gradient(145deg, #ffd29d, #ffad59);
-}
-
 @media (min-width: 768px) {
   body {
     padding: 32px;
@@ -251,23 +212,10 @@ body {
   .layout {
     grid-template-columns: minmax(280px, 360px) minmax(180px, 240px);
   }
-
-  .sidebar {
-    grid-template-rows: auto auto 1fr;
-  }
-
-  .mobile-controls {
-    align-self: end;
-  }
 }
 
 @media (max-width: 480px) {
   #app {
     width: 100%;
-  }
-
-  .controls-grid {
-    max-width: 100%;
-    grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -24,10 +24,7 @@ export interface AppOptions {
   playfieldCanvas: HTMLCanvasElement
   nextCanvas: HTMLCanvasElement
   pauseButton: HTMLButtonElement
-  controlButtons: HTMLButtonElement[]
 }
-
-type ControlAction = 'move-left' | 'move-right' | 'soft-drop' | 'rotate-right'
 
 export class GameApp {
   private readonly game = new Game()
@@ -35,7 +32,6 @@ export class GameApp {
   private readonly playfieldCtx: CanvasRenderingContext2D
   private readonly nextCtx: CanvasRenderingContext2D
   private readonly pauseButton: HTMLButtonElement
-  private readonly controlButtons: HTMLButtonElement[]
   private readonly scoreElement: HTMLElement
   private currentState: GameViewState | null = null
   private hasStarted = false
@@ -55,12 +51,10 @@ export class GameApp {
     this.playfieldCtx = playfieldCtx
     this.nextCtx = nextCtx
     this.pauseButton = options.pauseButton
-    this.controlButtons = options.controlButtons
     this.scoreElement = document.getElementById('score-value') ?? this.pauseButton
     this.loop = new GameLoop(this.game, (result) => this.handleFrame(result))
 
     this.bindPauseButton()
-    this.bindControlButtons()
     this.bindKeyboard()
   }
 
@@ -89,12 +83,6 @@ export class GameApp {
   dispose() {
     this.loop.stop()
     this.pauseButton.removeEventListener('click', this.handlePauseClick)
-    for (const button of this.controlButtons) {
-      button.removeEventListener('pointerdown', this.handlePointerDown)
-      button.removeEventListener('pointerup', this.handlePointerUp)
-      button.removeEventListener('pointerleave', this.handlePointerUp)
-      button.removeEventListener('pointercancel', this.handlePointerUp)
-    }
     window.removeEventListener('keydown', this.handleKeyDown)
     window.removeEventListener('keyup', this.handleKeyUp)
   }
@@ -112,54 +100,6 @@ export class GameApp {
 
   private readonly handlePauseClick = () => {
     this.togglePause()
-  }
-
-  private bindControlButtons() {
-    for (const button of this.controlButtons) {
-      button.addEventListener('pointerdown', this.handlePointerDown)
-      button.addEventListener('pointerup', this.handlePointerUp)
-      button.addEventListener('pointerleave', this.handlePointerUp)
-      button.addEventListener('pointercancel', this.handlePointerUp)
-    }
-  }
-
-  private readonly handlePointerDown = (event: PointerEvent) => {
-    const target = event.currentTarget as HTMLButtonElement
-    if (!this.hasStarted) return
-    target.setAttribute('data-active', 'true')
-    const action = target.dataset.action as ControlAction | undefined
-    if (!action) return
-    this.dispatchControl(action, true)
-  }
-
-  private readonly handlePointerUp = (event: PointerEvent) => {
-    const target = event.currentTarget as HTMLButtonElement
-    if (!this.hasStarted) return
-    target.removeAttribute('data-active')
-    const action = target.dataset.action as ControlAction | undefined
-    if (!action) return
-    this.dispatchControl(action, false)
-  }
-
-  private dispatchControl(action: ControlAction, pressed: boolean) {
-    if (!this.hasStarted) return
-    switch (action) {
-      case 'move-left':
-        if (pressed) this.loop.moveLeft()
-        break
-      case 'move-right':
-        if (pressed) this.loop.moveRight()
-        break
-      case 'soft-drop':
-        this.loop.setSoftDrop(pressed)
-        if (pressed) {
-          this.loop.softDropStep()
-        }
-        break
-      case 'rotate-right':
-        if (pressed) this.loop.rotateClockwise()
-        break
-    }
   }
 
   private bindKeyboard() {


### PR DESCRIPTION
## Summary
- gate the playfield behind a start screen and hide the gameplay view until the player starts
- remove the on-screen keyboard markup and associated styling from the layout
- simplify the game bootstrap code to drop control button handling that is no longer needed

## Testing
- `docker compose run --rm app npm run build` *(fails: docker: command not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9292db6c8329b7188cf7ceef8de4