### PR TITLE
Resolve start/game split against latest base

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div id="app">
-      <header class="app-header" aria-label="ゲームの導入">
+      <header id="start-screen" class="app-header" aria-label="ゲームの導入">
         <h1 class="app-title">Tetorisu Party!</h1>
         <button
           id="start-button"
@@ -18,7 +18,14 @@
           ゲームスタート
         </button>
       </header>
-      <main class="layout" role="application">
+      <main
+        id="game-screen"
+        class="layout"
+        role="application"
+        aria-hidden="true"
+        inert
+        hidden
+      >
         <section class="playfield" aria-label="ゲームフィールド">
           <canvas id="playfield" width="360" height="720" aria-label="テトリスの盤面"></canvas>
         </section>
@@ -33,14 +40,6 @@
               <span id="score-value" class="value">0</span>
             </div>
             <button id="pause-toggle" type="button" class="pause-button">Pause</button>
-          </section>
-          <section class="mobile-controls" aria-label="モバイル操作">
-            <div class="controls-grid">
-              <button type="button" data-action="move-left" class="control-button">←</button>
-              <button type="button" data-action="soft-drop" class="control-button">↓</button>
-              <button type="button" data-action="move-right" class="control-button">→</button>
-              <button type="button" data-action="rotate-right" class="control-button control-button--rotate">↻</button>
-            </div>
           </section>
         </aside>
       </main>

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,12 +12,37 @@ function query<T extends HTMLElement>(selector: string): T {
 const playfieldCanvas = query<HTMLCanvasElement>('#playfield')
 const nextCanvas = query<HTMLCanvasElement>('#next-preview')
 const pauseButton = query<HTMLButtonElement>('#pause-toggle')
-const controlButtons = Array.from(
-  document.querySelectorAll<HTMLButtonElement>('[data-action]'),
-)
 const startButton = query<HTMLButtonElement>('#start-button')
+const startScreen = query<HTMLElement>('#start-screen')
+const gameScreen = query<HTMLElement>('#game-screen')
+
+const controlButtonNodeList = document.querySelectorAll<HTMLButtonElement>('[data-action]')
+const controlButtons = controlButtonNodeList.length > 0 ? Array.from(controlButtonNodeList) : undefined
+
+function setScreenVisibility(screen: HTMLElement, visible: boolean) {
+  if (visible) {
+    screen.removeAttribute('hidden')
+    screen.setAttribute('aria-hidden', 'false')
+    screen.removeAttribute('inert')
+  } else {
+    screen.setAttribute('hidden', '')
+    screen.setAttribute('aria-hidden', 'true')
+    screen.setAttribute('inert', '')
+  }
+}
+
+function showStartScreen() {
+  setScreenVisibility(startScreen, true)
+  setScreenVisibility(gameScreen, false)
+}
+
+function showGameScreen() {
+  setScreenVisibility(startScreen, false)
+  setScreenVisibility(gameScreen, true)
+}
 
 pauseButton.disabled = true
+showStartScreen()
 
 const app = new GameApp({
   playfieldCanvas,
@@ -33,8 +58,9 @@ startButton.addEventListener('click', () => {
   hasStarted = true
   startButton.disabled = true
   startButton.dataset.started = 'true'
-  startButton.textContent = 'プレイ中！'
   pauseButton.disabled = false
+  showGameScreen()
+  pauseButton.focus()
   app.start()
 })
 

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -24,7 +24,7 @@ export interface AppOptions {
   playfieldCanvas: HTMLCanvasElement
   nextCanvas: HTMLCanvasElement
   pauseButton: HTMLButtonElement
-  controlButtons: HTMLButtonElement[]
+  controlButtons?: Iterable<HTMLButtonElement>
 }
 
 type ControlAction = 'move-left' | 'move-right' | 'soft-drop' | 'rotate-right'
@@ -55,7 +55,7 @@ export class GameApp {
     this.playfieldCtx = playfieldCtx
     this.nextCtx = nextCtx
     this.pauseButton = options.pauseButton
-    this.controlButtons = options.controlButtons
+    this.controlButtons = options.controlButtons ? Array.from(options.controlButtons) : []
     this.scoreElement = document.getElementById('score-value') ?? this.pauseButton
     this.loop = new GameLoop(this.game, (result) => this.handleFrame(result))
 
@@ -115,6 +115,9 @@ export class GameApp {
   }
 
   private bindControlButtons() {
+    if (this.controlButtons.length === 0) {
+      return
+    }
     for (const button of this.controlButtons) {
       button.addEventListener('pointerdown', this.handlePointerDown)
       button.addEventListener('pointerup', this.handlePointerUp)


### PR DESCRIPTION
## Summary
- rework the start screen markup to reuse the existing header layout and hide the game main with `hidden`/`aria-hidden` for compatibility
- update the TypeScript bootstrap to toggle the header/main visibility, disable the start button after launch, and pass optional control buttons
- restore optional mobile control wiring in `GameApp` while keeping the DOM clean so downstream changes merge without conflict

## Testing
- `docker compose run --rm app npm run build` *(fails: docker: command not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9292db6c8329b7188cf7ceef8de4