### PR TITLE
Implement start screen flow and hide game UI until start

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,13 @@
     <title>Tetorisu MVP</title>
   </head>
   <body>
-    <div id="app">
-      <section id="start-screen" class="start-screen" aria-label="ゲームの導入">
+    <div id="app" data-screen="intro">
+      <section
+        id="start-screen"
+        class="start-screen"
+        aria-label="ゲームの導入"
+        aria-hidden="false"
+      >
         <h1 class="app-title">Tetorisu Party!</h1>
         <button
           id="start-button"
@@ -18,7 +23,13 @@
           ゲームスタート
         </button>
       </section>
-      <main id="game-screen" class="layout" role="application" hidden>
+      <main
+        id="game-screen"
+        class="layout"
+        role="application"
+        aria-hidden="true"
+        hidden
+      >
         <section class="playfield" aria-label="ゲームフィールド">
           <canvas id="playfield" width="360" height="720" aria-label="テトリスの盤面"></canvas>
         </section>

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ function query<T extends HTMLElement>(selector: string): T {
   return element as T
 }
 
+const appRoot = query<HTMLElement>('#app')
 const playfieldCanvas = query<HTMLCanvasElement>('#playfield')
 const nextCanvas = query<HTMLCanvasElement>('#next-preview')
 const pauseButton = query<HTMLButtonElement>('#pause-toggle')
@@ -16,9 +17,12 @@ const startButton = query<HTMLButtonElement>('#start-button')
 const startScreen = query<HTMLElement>('#start-screen')
 const gameScreen = query<HTMLElement>('#game-screen')
 
+appRoot.dataset.screen = 'intro'
 pauseButton.disabled = true
 startScreen.hidden = false
+startScreen.setAttribute('aria-hidden', 'false')
 gameScreen.hidden = true
+gameScreen.setAttribute('aria-hidden', 'true')
 
 const app = new GameApp({
   playfieldCanvas,
@@ -35,8 +39,11 @@ startButton.addEventListener('click', () => {
   startButton.dataset.started = 'true'
   startButton.textContent = 'プレイ中！'
   pauseButton.disabled = false
+  appRoot.dataset.screen = 'playing'
   startScreen.hidden = true
+  startScreen.setAttribute('aria-hidden', 'true')
   gameScreen.hidden = false
+  gameScreen.setAttribute('aria-hidden', 'false')
   app.start()
 })
 

--- a/src/style.css
+++ b/src/style.css
@@ -41,6 +41,18 @@ body {
   gap: 24px;
 }
 
+#app[data-screen='intro'] #game-screen {
+  display: none;
+}
+
+#app[data-screen='playing'] #start-screen {
+  display: none;
+}
+
+#app[data-screen='playing'] #game-screen {
+  display: grid;
+}
+
 .app-title {
   margin: 0;
   font-size: clamp(2rem, 5vw, 3.5rem);


### PR DESCRIPTION
## Summary
- show only the title screen with a start button until play begins and mark the app root with the active screen state
- hide or reveal the game board, next preview, and score via CSS state selectors after the start button is pressed
- update accessibility attributes so the intro screen is hidden from assistive tech during gameplay

## Testing
- `docker compose run --rm app npm run build` *(fails: `docker` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf132235e48329bd2680e4c5d75d15