### PR TITLE
Adjust mobile playfield positioning

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -46,11 +46,15 @@ body {
 
 #app {
   position: relative;
+  --mobile-bottom-offset: 0px;
   width: min(100%, 960px);
-  min-height: calc(100vh - 2 * var(--page-padding-block, 0px));
-  max-height: calc(100dvh - 2 * var(--page-padding-block, 0px));
-  height: calc(100vh - 2 * var(--page-padding-block, 0px));
-  height: calc(100svh - 2 * var(--page-padding-block, 0px));
+  min-height:
+    calc(100vh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
+  max-height:
+    calc(100dvh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
+  height: calc(100vh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
+  height: calc(100svh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
+  height: calc(100dvh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -362,7 +366,7 @@ body {
 @media (max-width: 768px) {
   body {
     justify-content: flex-start;
-    align-items: stretch;
+    align-items: flex-start;
   }
 
   #app {
@@ -389,6 +393,12 @@ body {
 
   .pause-button {
     width: 100%;
+  }
+}
+
+@media (pointer: coarse) and (max-width: 768px) {
+  #app[data-screen='playing'] {
+    --mobile-bottom-offset: clamp(48px, 10vh, 72px);
   }
 }
 


### PR DESCRIPTION
## Summary
- introduce a mobile bottom offset variable on the app container so the playfield height can shrink when browser UI overlaps the viewport
- align the layout to the top on small screens and apply an offset for coarse pointers to keep the field clear of mobile browser controls

## Testing
- `docker compose run --rm app npm run build` *(fails: docker command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfddc0de408329bc85016b0a92e259