### PR TITLE
Fix sidebar controls resizing as score increases

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -288,6 +288,9 @@ body {
 .score__value {
   font-size: clamp(1.5rem, 3vw, 2.3rem);
   font-weight: 700;
+  display: inline-block;
+  min-width: 6ch;
+  text-align: right;
 }
 
 #orientation-guard {


### PR DESCRIPTION
## Summary
- reserve a fixed width for the score readout so the sidebar column stays stable as the score grows

## Testing
- not run (docker command unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d154a794748329b04615323045ee1c