### PR TITLE
Ensure playfield scales within the visible viewport

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -54,20 +54,33 @@ body {
 
 #app {
   position: relative;
-  --mobile-bottom-offset: 0px;
+  --mobile-bottom-offset: env(safe-area-inset-bottom, 0px);
+  --viewport-block-size: 100vh;
   width: min(100%, 960px);
   min-height:
-    calc(100vh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
+    calc(var(--viewport-block-size) - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
+  height:
+    calc(var(--viewport-block-size) - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
   max-height:
-    calc(100dvh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
-  height: calc(100vh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
-  height: calc(100svh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
-  height: calc(100dvh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
+    calc(var(--viewport-block-size) - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   gap: clamp(16px, 2vw, 24px);
   overflow: hidden;
+}
+
+@supports (height: 100svh) {
+  #app {
+    --viewport-block-size: 100svh;
+  }
+}
+
+@supports (height: 100dvh) {
+  #app {
+    max-height:
+      calc(100dvh - 2 * var(--page-padding-block, 0px) - var(--mobile-bottom-offset, 0px));
+  }
 }
 
 #app[data-screen='intro'] #game-screen {
@@ -188,7 +201,7 @@ body {
   height: 100%;
   width: auto;
   max-width: 100%;
-  aspect-ratio: 10 / 10;
+  aspect-ratio: 10 / 20;
   background: #151b24;
   border-radius: 8px;
   image-rendering: pixelated;
@@ -482,8 +495,9 @@ body {
 
   .playfield canvas {
     width: 100%;
-    height: 100%;
+    height: auto;
     max-width: 100%;
+    aspect-ratio: 10 / 20;
   }
 
   .sidebar {

--- a/src/ui/layout-scaler.ts
+++ b/src/ui/layout-scaler.ts
@@ -8,6 +8,7 @@ export class LayoutScaler {
   private readonly targets: HTMLElement[]
   private readonly options: LayoutScalerOptions
   private readonly observer: ResizeObserver | null
+  private readonly visualViewport: VisualViewport | null
   private readonly handleWindowResize: () => void
 
   constructor(root: HTMLElement, targets: HTMLElement[], options: LayoutScalerOptions = {}) {
@@ -21,6 +22,8 @@ export class LayoutScaler {
 
     this.observer = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(() => this.update()) : null
 
+    this.visualViewport = typeof window.visualViewport !== 'undefined' ? window.visualViewport : null
+
     if (this.observer) {
       this.observer.observe(this.root)
       for (const target of this.targets) {
@@ -29,13 +32,22 @@ export class LayoutScaler {
     }
 
     window.addEventListener('resize', this.handleWindowResize)
+    this.visualViewport?.addEventListener('resize', this.handleWindowResize)
+    this.visualViewport?.addEventListener('scroll', this.handleWindowResize)
     this.update()
   }
 
   update() {
-    const availableWidth = this.root.clientWidth
-    const availableHeight = this.root.clientHeight
+    const viewportHeight = this.visualViewport?.height ?? window.innerHeight
+    if (viewportHeight > 0) {
+      this.root.style.setProperty('--viewport-block-size', `${viewportHeight}px`)
+    }
+
+    const rootRect = this.root.getBoundingClientRect()
+    const availableWidth = rootRect.width
+    const availableHeight = rootRect.height
     const topOffset = this.options.topOffsetPx ?? 0
+    const clampedHeight = viewportHeight > 0 ? Math.min(availableHeight, viewportHeight) : availableHeight
 
     for (const target of this.targets) {
       if (!target.isConnected) {
@@ -56,9 +68,10 @@ export class LayoutScaler {
         continue
       }
 
-      const scale = Math.min(1, availableWidth / rect.width, availableHeight / rect.height)
+      const scaleHeight = rect.height === 0 ? 0 : clampedHeight / rect.height
+      const scale = Math.min(1, availableWidth / rect.width, scaleHeight)
       const scaledHeight = rect.height * scale
-      const offset = Math.max(0, (availableHeight - scaledHeight) / 2 - topOffset)
+      const offset = Math.max(0, (clampedHeight - scaledHeight) / 2 - topOffset)
 
       target.style.setProperty('--layout-scale', scale.toString())
       target.style.setProperty('--layout-offset-y', `${offset}px`)
@@ -70,5 +83,7 @@ export class LayoutScaler {
   dispose() {
     window.removeEventListener('resize', this.handleWindowResize)
     this.observer?.disconnect()
+    this.visualViewport?.removeEventListener('resize', this.handleWindowResize)
+    this.visualViewport?.removeEventListener('scroll', this.handleWindowResize)
   }
 }


### PR DESCRIPTION
## Summary
- track the actual viewport height and expose it to the layout via a CSS variable
- clamp the playfield layout scaling to the visible viewport using VisualViewport when available
- include safe-area insets when sizing the app container for better mobile rendering

## Testing
- not run (docker command unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc57e5684883298bd4d198d1ac7043